### PR TITLE
update filepath to fix broken images

### DIFF
--- a/workshop/content/lab1.2_how_works.md
+++ b/workshop/content/lab1.2_how_works.md
@@ -5,7 +5,7 @@ Red Hat OpenShift Serverless delivers Kubernetes-native, event-driven primitives
 ## Architecture
 At a high level, Serverless -- specifically the Knative project -- is composed of two main components: Eventing and Serving.  These two components work together to create an event driven architecture that is a critical part of the Serverless paradigm.
 
-![OpenShift Serverless Architecture](content/images/serverless_eventing_serving.png)*Architecture*
+![OpenShift Serverless Architecture](images/serverless_eventing_serving.png)*Architecture*
 
 ### Eventing
 Eventing is the part of the infrastructure for consuming external events and producing a cloud specific event called a CloudEvent.  A CloudEvent is a CNCF specfication for describing cloud event data in a common way.  It seeks to be consistent, accessible across a variety of languages, and portable.  This eventing abstraction is a useful one as it allows developers to only have to think about functional areas of the system that concerns them.  For instance, thinking about applications in an evented way allows for loosely coupled, independent services.  This also allows developers to work on specific aspects of a given application in a variety of ways:

--- a/workshop/content/lab1.3_configure.md
+++ b/workshop/content/lab1.3_configure.md
@@ -8,19 +8,19 @@ OpenShift Serverless install can be completely done with Operator Hub webconsole
 
 In OpenShift, installation of Knative is very easy.  You just need to find and install the OpenShift Serverless Operator.
 
-![OpenShift Serverless Operator Hub](content/images/serverless_operator_hub.png)*Operator Hub*
+![OpenShift Serverless Operator Hub](images/serverless_operator_hub.png)*Operator Hub*
 
 Then click install.
 
-![Install OpenShift Serverless Operator](content/images/serverless_install_operator.png)*OpenShift Serverless Operator*
+![Install OpenShift Serverless Operator](images/serverless_install_operator.png)*OpenShift Serverless Operator*
 
 Next make sure to install in all namespaces.  Select the latest Update Channel made available to you.  For the purposes of this demo, we'll pick the Manual approval strategy.  Lastly, click Subscribe.
 
-![Subscribe to OpenShift Serverless Operator](content/images/serverless_create_subscription.png)*Subscribe*
+![Subscribe to OpenShift Serverless Operator](images/serverless_create_subscription.png)*Subscribe*
 
 Wait a few minutes and eventually you will see it show up as Installed Operator with the status of Succeeded
 
-![Subscribe to OpenShift Serverless Operator](content/images/serverless_installed_operator.png)*Installed*
+![Subscribe to OpenShift Serverless Operator](images/serverless_installed_operator.png)*Installed*
 
 
 ## Knative Serving Installation


### PR DESCRIPTION
Silly mistake by me.  When I moved the markdown files into the content directory I didn't update the image paths.